### PR TITLE
Fix interactive demo loader

### DIFF
--- a/demos/brightpath/docs/javascript/global.js
+++ b/demos/brightpath/docs/javascript/global.js
@@ -52,9 +52,14 @@ function hideLoader() {
     }, Math.max(0, remainingTime));
 }
 
-// Example usage:
-showLoader();
-// simulate some async task (like fetch or form submission)
-setTimeout(() => {
-    hideLoader();
-}, 200); // even if task is fast, loader will stay at least 0.5s
+// Only run the loader when this page isn't embedded in an iframe
+const isEmbedded = window.self !== window.top;
+
+if (!isEmbedded) {
+    // Example usage on standalone pages
+    showLoader();
+    // simulate some async task (like fetch or form submission)
+    setTimeout(() => {
+        hideLoader();
+    }, 200); // even if task is fast, loader will stay at least 0.5s
+}

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
   <!-- Right: Framed Interactive Demo -->
   <div class="synx-device-frame">
     <!-- Skeleton loader -->
-    <div class="synx-skeleton"></div>
+    <div class="synx-skeleton" style="display:none;"></div>
     <!-- Preview overlay with play icon -->
     <div class="synx-preview">
       <div class="synx-play-icon">&#9658;</div>
@@ -279,7 +279,7 @@
     // Show live demo when the preview is clicked
     preview.addEventListener('click', () => {
       preview.style.display = 'none';
-      skeleton.style.display = 'none';
+      skeleton.style.display = 'block';
       iframe.style.display  = 'block';
     });
 


### PR DESCRIPTION
## Summary
- disable BrightPath loader when embedded in iframe
- hide demo skeleton by default and show it only during load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68743f958cf8832d86bf2a30e3674283